### PR TITLE
Optional phone number

### DIFF
--- a/components/ApplicationForm.tsx
+++ b/components/ApplicationForm.tsx
@@ -84,7 +84,13 @@ const ApplicationForm = ({ quiz }: Props) => {
               label="Email"
               name="email"
               type="email"
-              hint="We'll send a confirmation email to this address."
+              hint="We'll send a confirmation email to this address"
+            />
+            <Field
+              label="Phone number"
+              name="optionalPhone"
+              type="optionalPhone"
+              hint="Optional"
             />
             <Field
               label="Include my answers?"

--- a/components/ApplicationForm.tsx
+++ b/components/ApplicationForm.tsx
@@ -105,7 +105,7 @@ const ApplicationForm = ({ quiz }: Props) => {
 
             {contactPref === ContactPreference.Text && (
               <Field
-                label="Mobile phone"
+                label="Confirm mobile number"
                 name="phone"
                 type="tel"
                 hint="We'll text you on this number"
@@ -114,7 +114,7 @@ const ApplicationForm = ({ quiz }: Props) => {
 
             {contactPref === ContactPreference.Phone && (
               <Field
-                label="Phone"
+                label="Confirm phone number"
                 name="phone"
                 type="tel"
                 hint="We'll call you on this number"

--- a/components/ApplicationForm.tsx
+++ b/components/ApplicationForm.tsx
@@ -88,9 +88,8 @@ const ApplicationForm = ({ quiz }: Props) => {
             />
             <Field
               label="Phone number"
-              name="optionalPhone"
-              type="optionalPhone"
-              hint="Optional"
+              name="phone"
+              type="phone"
             />
             <Field
               label="Include my answers?"
@@ -108,24 +107,6 @@ const ApplicationForm = ({ quiz }: Props) => {
               label="How would you like to chat with us?"
               options={ContactPreference}
             />
-
-            {contactPref === ContactPreference.Text && (
-              <Field
-                label="Confirm mobile number"
-                name="phone"
-                type="tel"
-                hint="We'll text you on this number"
-              />
-            )}
-
-            {contactPref === ContactPreference.Phone && (
-              <Field
-                label="Confirm phone number"
-                name="phone"
-                type="tel"
-                hint="We'll call you on this number"
-              />
-            )}
 
             <RadioField
               name="levelOfInterest"

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -8,16 +8,13 @@ export const generateApplicationSchema = (eventsAvailable: boolean) =>
       .string()
       .required("That doesn't look like a valid email")
       .email("That doesn't look like a valid email"),
-    phone: yup.string().when("contactPreference", {
-      is: ContactPreference.Phone || ContactPreference.Text,
-      then: yup
-        .string()
-        .required("That doesn't look like a valid phone number")
-        .matches(
-          /^(((\+44\s?\d{4}|\(?0\d{4}\)?)\s?\d{3}\s?\d{3})|((\+44\s?\d{3}|\(?0\d{3}\)?)\s?\d{3}\s?\d{4})|((\+44\s?\d{2}|\(?0\d{2}\)?)\s?\d{4}\s?\d{4}))(\s?\#(\d{4}|\d{3}))?$/,
-          "That doesn't look like a valid phone number"
-        ),
-    }),
+    phone: yup
+      .string()
+      .required("That doesn't look like a valid phone number")
+      .matches(
+        /^(((\+44\s?\d{4}|\(?0\d{4}\)?)\s?\d{3}\s?\d{3})|((\+44\s?\d{3}|\(?0\d{3}\)?)\s?\d{3}\s?\d{4})|((\+44\s?\d{2}|\(?0\d{2}\)?)\s?\d{4}\s?\d{4}))(\s?\#(\d{4}|\d{3}))?$/,
+        "That doesn't look like a valid phone number"
+      ),
     firstName: yup.string().required("You need to give your first name"),
     lastName: yup.string().required("You need to give your last name"),
     includeAnswers: yup.boolean(),
@@ -38,16 +35,6 @@ export const generateApplicationSchema = (eventsAvailable: boolean) =>
       .typeError("You need to tell us how interested you are")
       .required("You need to tell us how interested you are"),
     discussionTopics: yup.string(),
-    optionalPhone: yup
-      .string()
-      .notRequired()
-      .matches(
-        /^(((\+44\s?\d{4}|\(?0\d{4}\)?)\s?\d{3}\s?\d{3})|((\+44\s?\d{3}|\(?0\d{3}\)?)\s?\d{3}\s?\d{4})|((\+44\s?\d{2}|\(?0\d{2}\)?)\s?\d{4}\s?\d{4}))(\s?\#(\d{4}|\d{3}))?$/,
-        {
-          message: "That doesn't look like a valid phone number",
-          excludeEmptyString: true,
-        }
-      ),
   })
 
 export const generateQuestionSchema = (question: Question) => {

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -38,6 +38,16 @@ export const generateApplicationSchema = (eventsAvailable: boolean) =>
       .typeError("You need to tell us how interested you are")
       .required("You need to tell us how interested you are"),
     discussionTopics: yup.string(),
+    optionalPhone: yup
+      .string()
+      .notRequired()
+      .matches(
+        /^(((\+44\s?\d{4}|\(?0\d{4}\)?)\s?\d{3}\s?\d{3})|((\+44\s?\d{3}|\(?0\d{3}\)?)\s?\d{3}\s?\d{4})|((\+44\s?\d{2}|\(?0\d{2}\)?)\s?\d{4}\s?\d{4}))(\s?\#(\d{4}|\d{3}))?$/,
+        {
+          message: "That doesn't look like a valid phone number",
+          excludeEmptyString: true,
+        }
+      ),
   })
 
 export const generateQuestionSchema = (question: Question) => {


### PR DESCRIPTION
The original [design ticket](https://trello.com/c/Fbl8tkhP/28-ask-for-phone-number-as-optional-in-booking-form) asked for an optional phone field then confirming fields under the contact options.

This has been updated to a single form field for collecting the phone number. Discussion [here in Slack](https://amyrogers.slack.com/archives/C04NLGT56BW/p1685714792626659).